### PR TITLE
Add "setup_fiscal_calendar" function.

### DIFF
--- a/fiscalyear.py
+++ b/fiscalyear.py
@@ -24,8 +24,8 @@ START_MONTH = 10
 START_DAY = 1
 
 
-def validate_fiscal_calendar_params(start_year, start_month, start_day):
-    """ Raise an Exception if the calendar parameters are invalid.
+def _validate_fiscal_calendar_params(start_year, start_month, start_day):
+    """Raise an Exception if the calendar parameters are invalid.
 
     :param start_year: Relationship between the start of the fiscal year and
         the calendar year. Possible values: ``'previous'`` or ``'same'``.
@@ -47,7 +47,7 @@ def validate_fiscal_calendar_params(start_year, start_month, start_day):
 
 
 def setup_fiscal_calendar(start_year, start_month, start_day):
-    validate_fiscal_calendar_params(start_year, start_month, start_day)
+    _validate_fiscal_calendar_params(start_year, start_month, start_day)
     global START_YEAR, START_MONTH, START_DAY
     START_YEAR = start_year
     START_MONTH = start_month

--- a/fiscalyear.py
+++ b/fiscalyear.py
@@ -36,17 +36,20 @@ def _validate_fiscal_calendar_params(start_year, start_month, start_day):
     :type start_day: int or str
     :raises TypeError: If ``start_year`` is not a ``str``.
     :raises ValueError: If ``start_year`` is not ``'previous'`` or ``'same'``
-    :raises ValueError: If ``start_month`` or ``start_day`` is not an int or int-like string
+    :raises ValueError: If ``start_month`` or ``start_day`` is not an int or
+        int-like string
     :raises ValueError: If ``start_month`` or ``start_day`` is out of range
     """
     if not isinstance(start_year, str):
         raise TypeError("'start_year' must be a 'str', not: '%s'" % type(str))
-    if not start_year in ('previous',  'same'):
-        raise ValueError("start_year must be either 'previous' or 'same', not: '%s'" % start_year)
+    if start_year not in ('previous',  'same'):
+        msg = "'start_year' must be either 'previous' or 'same', not: '%s'"
+        raise ValueError(msg % start_year)
     _check_day(start_month, start_day)
 
 
 def setup_fiscal_calendar(start_year, start_month, start_day):
+    """Change the global calendar settings."""
     _validate_fiscal_calendar_params(start_year, start_month, start_day)
     global START_YEAR, START_MONTH, START_DAY
     START_YEAR = start_year
@@ -67,19 +70,21 @@ def fiscal_calendar(start_year=None, start_month=None, start_day=None):
     :param start_day: The first day of the first month of the fiscal year
     :type start_day: int or str
     :raises ValueError: If ``start_year`` is not ``'previous'`` or ``'same'``
-    :raises TypeError: If ``start_month`` or ``start_day`` is not an int or int-like string
+    :raises TypeError: If ``start_month`` or ``start_day`` is not an int or
+        int-like string
     :raises ValueError: If ``start_month`` or ``start_day`` is out of range
     """
-    # if arguments are omitted, use the currently active values.
+    # If arguments are omitted, use the currently active values.
     start_year = START_YEAR if start_year is None else start_year
     start_month = START_MONTH if start_month is None else start_month
     start_day = START_DAY if start_day is None else start_day
 
-    # Temporarily change global variables and then restore previous values
-    old_start_year, old_start_month, old_start_day = START_YEAR, START_MONTH, START_DAY
+    # Temporarily change global variables
+    previous_values = (START_YEAR, START_MONTH, START_DAY)
     setup_fiscal_calendar(start_year, start_month, start_day)
     yield
-    setup_fiscal_calendar(old_start_year, old_start_month, old_start_day)
+    # Restore previous values
+    setup_fiscal_calendar(*previous_values)
 
 
 def _check_int(value):

--- a/fiscalyear.py
+++ b/fiscalyear.py
@@ -230,11 +230,9 @@ class FiscalYear(object):
             return self == item
         elif isinstance(item, FiscalQuarter):
             return self._fiscal_year == item.fiscal_year
-        elif (isinstance(item, FiscalDateTime) or
-              isinstance(item, datetime.datetime)):
+        elif isinstance(item, datetime.datetime):
             return self.start <= item <= self.end
-        elif (isinstance(item, FiscalDate) or
-              isinstance(item, datetime.date)):
+        elif isinstance(item, datetime.date):
             return self.start.date() <= item <= self.end.date()
         else:
             raise TypeError("can't compare '%s' to '%s'" % (
@@ -410,11 +408,9 @@ class FiscalQuarter(object):
         """
         if isinstance(item, FiscalQuarter):
             return self == item
-        elif (isinstance(item, FiscalDateTime) or
-              isinstance(item, datetime.datetime)):
+        elif isinstance(item, datetime.datetime):
             return self.start <= item <= self.end
-        elif (isinstance(item, FiscalDate) or
-              isinstance(item, datetime.date)):
+        elif isinstance(item, datetime.date):
             return self.start.date() <= item <= self.end.date()
         else:
             raise TypeError("can't compare '%s' to '%s'" % (

--- a/test_fiscalyear.py
+++ b/test_fiscalyear.py
@@ -70,6 +70,27 @@ class TestCheckDay(object):
     @pytest.mark.parametrize("month, day", [(1, 1), (1, 2), (1, "1"), (1, 31), (1, "31")])
     def test_valid_input(self, month, day):
         assert int(day) == fiscalyear._check_day(month, day)
+
+
+class TestCheckQuarter(object):
+    @pytest.mark.parametrize("value, exception", [
+        ('asdf', TypeError),
+        (float(), TypeError),
+        (object(), TypeError),
+        ("-1", TypeError),
+        (-1, ValueError),
+        (0, ValueError),
+        ("0", ValueError),
+        (5, ValueError),
+        ("5", ValueError),
+    ])
+    def test_invalid_input(self, value, exception):
+        with pytest.raises(exception):
+            fiscalyear._check_quarter(value)
+
+    @pytest.mark.parametrize("value", [1, 2, "1", "4"])
+    def test_valid_input(self, value):
+        assert int(value) == fiscalyear._check_quarter(value)
 class TestFiscalCalendar:
 
     def test_start_year(self):

--- a/test_fiscalyear.py
+++ b/test_fiscalyear.py
@@ -50,6 +50,26 @@ class TestCheckYear(object):
         assert int(value) == fiscalyear._check_year(value)
 
 
+class TestCheckDay(object):
+    @pytest.mark.parametrize("month, day, exception", [
+        (1, 'asdf', TypeError),
+        (1, "-999", TypeError),                # Shouldn't this be valid?
+        (1, float(), TypeError),
+        (1, object(), TypeError),
+        (1, -1, ValueError),
+        (1, "-1", TypeError),
+        (1, 0, ValueError),
+        (1, "0", ValueError),
+        (1, 32, ValueError),
+        (1, 32, ValueError),
+    ])
+    def test_invalid_input(self, month, day, exception):
+        with pytest.raises(exception):
+            fiscalyear._check_day(month, day)
+
+    @pytest.mark.parametrize("month, day", [(1, 1), (1, 2), (1, "1"), (1, 31), (1, "31")])
+    def test_valid_input(self, month, day):
+        assert int(day) == fiscalyear._check_day(month, day)
 class TestFiscalCalendar:
 
     def test_start_year(self):

--- a/test_fiscalyear.py
+++ b/test_fiscalyear.py
@@ -9,8 +9,6 @@ import pytest
 US_FEDERAL = ('previous', 10, 1)
 UK_PERSONAL = ('same', 4, 6)
 
-# Default to U.S.
-fiscalyear.START_YEAR, fiscalyear.START_MONTH, fiscalyear.START_DAY = US_FEDERAL
 
 
 class TestCheckInt(object):

--- a/test_fiscalyear.py
+++ b/test_fiscalyear.py
@@ -13,7 +13,10 @@ UK_PERSONAL = ('same', 4, 6)
 class TestCheckInt(object):
     @pytest.mark.parametrize("value, exception", [
         ('asdf', TypeError),
-        ("-999", TypeError),                # Shouldn't this be valid?
+        ("-999", TypeError),
+        # Technically speaking, _check_int should accept negative integers
+        # but this isn't a public function + datetime doesn't handle them
+        # anyeway.
         (float(), TypeError),
         (object(), TypeError),
     ])
@@ -50,7 +53,7 @@ class TestCheckYear(object):
 class TestCheckDay(object):
     @pytest.mark.parametrize("month, day, exception", [
         (1, 'asdf', TypeError),
-        (1, "-999", TypeError),                # Shouldn't this be valid?
+        (1, "-999", TypeError),
         (1, float(), TypeError),
         (1, object(), TypeError),
         (1, -1, ValueError),
@@ -95,14 +98,14 @@ class TestCalendarSettingsValidator(object):
         (dict(start_year='asdf', start_month=12, start_day=1), ValueError),
         (dict(start_year=float(1999), start_month=12, start_day=1), TypeError),
         (dict(start_year=object(), start_month=12, start_day=1), TypeError),
-        #
+
         (dict(start_year='same', start_month='asdf', start_day=1), TypeError),
         (dict(start_year='same', start_month=float(12), start_day=1), TypeError),
         (dict(start_year='same', start_month=object(), start_day=1), TypeError),
         (dict(start_year='same', start_month=-1, start_day=1), ValueError),
         (dict(start_year='same', start_month=0, start_day=1), ValueError),
         (dict(start_year='same', start_month=13, start_day=1), ValueError),
-        #
+
         (dict(start_year='same', start_month=12, start_day='asdf'), TypeError),
         (dict(start_year='same', start_month=12, start_day=float(1)), TypeError),
         (dict(start_year='same', start_month=12, start_day=object()), TypeError),
@@ -125,22 +128,24 @@ class TestCalendarSettingsValidator(object):
     def test_valid_input(self, arguments):
         fiscalyear._validate_fiscal_calendar_params(**arguments)
 
-def test_setup_fiscal_calendar():
-    # test defaults
-    day =  fiscalyear.FiscalDate(2017, 12, 1)
-    assert day.fiscal_year == 2018
-    assert day.quarter == 1
 
-    # change fiscal year settings
-    fiscalyear.setup_fiscal_calendar("same", 1, 1)
-    assert day.fiscal_year == 2017
-    assert day.quarter == 4
+class TestSetupFiscalCalendar(object):
 
-    # restore defaults and re-test
-    fiscalyear.setup_fiscal_calendar("previous", 10, 1)
-    assert day.fiscal_year == 2018
-    assert day.quarter == 1
+    def test_setup_fiscal_calendar(self):
+        # Test defaults
+        day =  fiscalyear.FiscalDate(2017, 12, 1)
+        assert day.fiscal_year == 2018
+        assert day.quarter == 1
 
+        # Change fiscal year settings
+        fiscalyear.setup_fiscal_calendar("same", 1, 1)
+        assert day.fiscal_year == 2017
+        assert day.quarter == 4
+
+        # Restore defaults and re-test
+        fiscalyear.setup_fiscal_calendar("previous", 10, 1)
+        assert day.fiscal_year == 2018
+        assert day.quarter == 1
 
 
 class TestFiscalCalendar:

--- a/test_fiscalyear.py
+++ b/test_fiscalyear.py
@@ -114,6 +114,16 @@ class TestCalendarSettingsValidator(object):
         with pytest.raises(exception):
             fiscalyear.validate_fiscal_calendar_params(**arguments)
 
+    @pytest.mark.parametrize("arguments", [
+        dict(start_year='same', start_month=1, start_day=1),
+        dict(start_year='same', start_month=1, start_day=31),
+        dict(start_year='same', start_month=12, start_day=1),
+        dict(start_year='previous', start_month=1, start_day=1),
+        dict(start_year='previous', start_month=1, start_day=31),
+        dict(start_year='previous', start_month=12, start_day=1),
+    ])
+    def test_valid_input(self, arguments):
+        fiscalyear.validate_fiscal_calendar_params(**arguments)
 
 def test_setup_fiscal_calendar():
     # test defaults

--- a/test_fiscalyear.py
+++ b/test_fiscalyear.py
@@ -13,6 +13,22 @@ UK_PERSONAL = ('same', 4, 6)
 fiscalyear.START_YEAR, fiscalyear.START_MONTH, fiscalyear.START_DAY = US_FEDERAL
 
 
+class TestCheckInt(object):
+    @pytest.mark.parametrize("value, exception", [
+        ('asdf', TypeError),
+        ("-999", TypeError),                # Shouldn't this be valid?
+        (float(), TypeError),
+        (object(), TypeError),
+    ])
+    def test_invalid_input(self, value, exception):
+        with pytest.raises(exception):
+            fiscalyear._check_int(value)
+
+    @pytest.mark.parametrize("value", [1, 2, 0, -1, -2, "1", "0", "999"])
+    def test_valid_input(self, value):
+        assert int(value) == fiscalyear._check_int(value)
+
+
 class TestFiscalCalendar:
 
     def test_start_year(self):

--- a/test_fiscalyear.py
+++ b/test_fiscalyear.py
@@ -29,6 +29,27 @@ class TestCheckInt(object):
         assert int(value) == fiscalyear._check_int(value)
 
 
+class TestCheckYear(object):
+    @pytest.mark.parametrize("value, exception", [
+        ('asdf', TypeError),
+        (float(), TypeError),
+        (object(), TypeError),
+        ("-1", TypeError),
+        (-1, ValueError),
+        (0, ValueError),
+        ("0", ValueError),
+        (10000, ValueError),
+        ("10000", ValueError),
+    ])
+    def test_invalid_input(self, value, exception):
+        with pytest.raises(exception):
+            fiscalyear._check_year(value)
+
+    @pytest.mark.parametrize("value", [1, 2, "1", "999"])
+    def test_valid_input(self, value):
+        assert int(value) == fiscalyear._check_year(value)
+
+
 class TestFiscalCalendar:
 
     def test_start_year(self):

--- a/test_fiscalyear.py
+++ b/test_fiscalyear.py
@@ -16,7 +16,7 @@ class TestCheckInt(object):
         ("-999", TypeError),
         # Technically speaking, _check_int should accept negative integers
         # but this isn't a public function + datetime doesn't handle them
-        # anyeway.
+        # anyway.
         (float(), TypeError),
         (object(), TypeError),
     ])

--- a/test_fiscalyear.py
+++ b/test_fiscalyear.py
@@ -112,7 +112,7 @@ class TestCalendarSettingsValidator(object):
     ])
     def test_invalid_input(self, arguments, exception):
         with pytest.raises(exception):
-            fiscalyear.validate_fiscal_calendar_params(**arguments)
+            fiscalyear._validate_fiscal_calendar_params(**arguments)
 
     @pytest.mark.parametrize("arguments", [
         dict(start_year='same', start_month=1, start_day=1),
@@ -123,7 +123,7 @@ class TestCalendarSettingsValidator(object):
         dict(start_year='previous', start_month=12, start_day=1),
     ])
     def test_valid_input(self, arguments):
-        fiscalyear.validate_fiscal_calendar_params(**arguments)
+        fiscalyear._validate_fiscal_calendar_params(**arguments)
 
 def test_setup_fiscal_calendar():
     # test defaults


### PR DESCRIPTION
This makes it easier to change the global Calendar Settings without having
to jump through hoops.

It also makes it possible to simplify the `fiscal_calendar` implementation.

Note 1: The advanced docs will need to be updated.

Fixes #3