### PR TITLE
Add fiscal_month attribute to FiscalDateTime and FiscalDate

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,8 @@ The start and end of each quarter are stored as instances of the ``FiscalDateTim
    FiscalDateTime(2017, 4, 8, 20, 30, 31, 105323)
    >>> c.fiscal_year
    2017
+   >>> c.fiscal_month
+   7
    >>> c.quarter
    3
    >>> c.next_quarter

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@
 Overview
 ========
 
-`fiscalyear <https://github.com/adamjstewart/fiscalyear>`_ is a small, lightweight Python module providing helpful utilities for managing the fiscal calendar. It is designed as an extension of the built-in `datetime <https://docs.python.org/3/library/datetime.html>`_ and `calendar <https://docs.python.org/3/library/calendar.html>`_ modules, adding the ability to query the fiscal year and fiscal quarter of a date or datetime object.
+`fiscalyear <https://github.com/adamjstewart/fiscalyear>`_ is a small, lightweight Python module providing helpful utilities for managing the fiscal calendar. It is designed as an extension of the built-in `datetime <https://docs.python.org/3/library/datetime.html>`_ and `calendar <https://docs.python.org/3/library/calendar.html>`_ modules, adding the ability to query the fiscal year, fiscal month, and fiscal quarter of a date or datetime object.
 
 
 Basic Usage

--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ You can also get the current ``FiscalQuarter`` with:
 FiscalDateTime
 --------------
 
-The start and end of each quarter are stored as instances of the ``FiscalDateTime`` class. This class provides all of the same features as the ``datetime`` class, with the addition of the ability to query the fiscal year and quarter.
+The start and end of each quarter are stored as instances of the ``FiscalDateTime`` class. This class provides all of the same features as the ``datetime`` class, with the addition of the ability to query the fiscal year, fiscal month, and quarter.
 
 .. code-block:: python
 

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -64,7 +64,7 @@ You can also get the current ``FiscalQuarter`` with:
 FiscalDateTime
 --------------
 
-The start and end of each quarter are stored as instances of the ``FiscalDateTime`` class. This class provides all of the same features as the ``datetime`` class, with the addition of the ability to query the fiscal year and quarter.
+The start and end of each quarter are stored as instances of the ``FiscalDateTime`` class. This class provides all of the same features as the ``datetime`` class, with the addition of the ability to query the fiscal year, fiscal month, and quarter.
 
 .. code-block:: python
 
@@ -73,6 +73,8 @@ The start and end of each quarter are stored as instances of the ``FiscalDateTim
    FiscalDateTime(2017, 4, 8, 20, 30, 31, 105323)
    >>> c.fiscal_year
    2017
+   >>> c.fiscal_month
+   7
    >>> c.quarter
    3
    >>> c.next_quarter

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 fiscalyear
 ==========
 
-`fiscalyear <https://github.com/adamjstewart/fiscalyear>`_ is a small, lightweight Python module providing helpful utilities for managing the fiscal calendar. It is designed as an extension of the built-in `datetime <https://docs.python.org/3/library/datetime.html>`_ and `calendar <https://docs.python.org/3/library/calendar.html>`_ modules, adding the ability to query the fiscal year and fiscal quarter of a date or datetime object.
+`fiscalyear <https://github.com/adamjstewart/fiscalyear>`_ is a small, lightweight Python module providing helpful utilities for managing the fiscal calendar. It is designed as an extension of the built-in `datetime <https://docs.python.org/3/library/datetime.html>`_ and `calendar <https://docs.python.org/3/library/calendar.html>`_ modules, adding the ability to query the fiscal year, fiscal month, and fiscal quarter of a date or datetime object.
 
 
 .. toctree::

--- a/fiscalyear.py
+++ b/fiscalyear.py
@@ -625,6 +625,9 @@ class _FiscalBase:
 
     @property
     def fiscal_month(self):
+        """:returns: The fiscal month
+        :rtype: int
+        """
         return (self.month - FiscalYear(self.year).start.month) % 12 + 1
 
     @property

--- a/fiscalyear.py
+++ b/fiscalyear.py
@@ -624,6 +624,10 @@ class _FiscalBase:
             return self.year - 1
 
     @property
+    def fiscal_month(self):
+        return (self.month - FiscalYear(self.year).start.month) % 12 + 1
+
+    @property
     def prev_fiscal_year(self):
         """:returns: The previous fiscal year
         :rtype: FiscalYear

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 codecov
-pytest==4.6.11
+pytest<=4
 pytest-cov
 pytest-mock==2.0.0
 pytest-runner

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 codecov
 pytest~=4.6
 pytest-cov
-pytest-mock~=2
+pytest-mock~=2.0
 pytest-runner
 sphinx
 sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 codecov
-pytest
+pytest==6.1.1
 pytest-cov
 pytest-mock
 pytest-runner

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 codecov
 pytest~=4.6
 pytest-cov
-pytest-mock<=2
+pytest-mock~=2
 pytest-runner
 sphinx
 sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 codecov
-pytest==6.1.1
+pytest==4.6.11
 pytest-cov
-pytest-mock
+pytest-mock==2.0.0
 pytest-runner
 sphinx
 sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 codecov
 pytest<=4
 pytest-cov
-pytest-mock==2.0.0
+pytest-mock<=2
 pytest-runner
 sphinx
 sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 codecov
-pytest<=4
+pytest~=4.6
 pytest-cov
 pytest-mock<=2
 pytest-runner

--- a/test_fiscalyear.py
+++ b/test_fiscalyear.py
@@ -668,16 +668,22 @@ class TestFiscalDate:
         assert a.day == 1
 
         assert a.fiscal_year == 2017
+        assert a.fiscal_month == 4
         assert a.quarter == 2
 
-    def test_fiscal_year(self, a, c):
+    def test_fiscal_periods(self, a, c):
         with fiscalyear.fiscal_calendar(*US_FEDERAL):
             assert a.fiscal_year == 2017
+            assert a.fiscal_month == 4
             assert c.fiscal_year == 2018
+            assert c.fiscal_month == 2
+
 
         with fiscalyear.fiscal_calendar(*UK_PERSONAL):
             assert a.fiscal_year == 2016
+            assert a.fiscal_month == 10
             assert c.fiscal_year == 2017
+            assert c.fiscal_month == 8
 
     def test_prev_fiscal_year(self, a):
         assert a.prev_fiscal_year == fiscalyear.FiscalYear(2016)
@@ -719,14 +725,18 @@ class TestFiscalDateTime:
         assert a.fiscal_year == 2017
         assert a.quarter == 2
 
-    def test_fiscal_year(self, a, c):
+    def test_fiscal_periods(self, a, c):
         with fiscalyear.fiscal_calendar(*US_FEDERAL):
             assert a.fiscal_year == 2017
+            assert a.fiscal_month == 4
             assert c.fiscal_year == 2018
+            assert c.fiscal_month == 2
 
         with fiscalyear.fiscal_calendar(*UK_PERSONAL):
             assert a.fiscal_year == 2016
+            assert a.fiscal_month == 10
             assert c.fiscal_year == 2017
+            assert c.fiscal_month == 8
 
     def test_prev_fiscal_year(self, a):
         assert a.prev_fiscal_year == fiscalyear.FiscalYear(2016)


### PR DESCRIPTION
This PR specifically adds a fiscal_month attribute (and does _not_ add a correspondingFiscalMonth object). I can follow up with fiscal_week and fiscal_day if desired, but I really needed this functionality for my use case and I'm hoping this PR stands on its own. It's pretty simple, and I think the approach could be quickly adapted to those two additional calculations if/when desired.

Please let me know if the PR is missing anything.