### PR TITLE
FiscalMonth/Day documentation expansion

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,6 +79,8 @@ These objects represent the standalone ``FiscalQuarter`` class.
    True
    >>> b in a
    True
+   >>> b.next_quarter
+   FiscalQuarter(2017, 4)
 
 You can also get the current ``FiscalQuarter`` with:
 
@@ -102,6 +104,8 @@ FiscalMonth
    True
    >>> c in b
    True
+   >>> c.next_fiscal_month
+   FiscalMonth(2017, 10)
 
 You can also get the current ``FiscalMonth`` with:
 
@@ -127,6 +131,8 @@ FiscalDay
    True
    >>> d in c
    True
+   >>>d.next_fiscal_day
+   FiscalDay(2017, 251)
 
 You can also get the current ``FiscalDay`` with:
 

--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,54 @@ You can also get the current ``FiscalQuarter`` with:
    FiscalQuarter(2018, 2)
 
 
+FiscalMonth
+----------
+
+.. code-block:: python
+
+   >>> c = FiscalMonth(2017, 9)
+   >>> c.start
+   FiscalDateTime(2017, 6, 1, 0, 0)
+   >>> c.end
+   FiscalDateTime(2017, 6, 30, 23, 59, 59)
+   >>> c in a
+   True
+   >>> c in b
+   True
+
+You can also get the current ``FiscalMonth`` with:
+
+.. code-block:: python
+
+   >>> FiscalMonth.current()
+   FiscalMonth(2018, 4)
+
+
+FiscalDay
+----------
+
+.. code-block:: python
+
+   >>> d = FiscalDay(2017, 250)
+   >>> d.start
+   FiscalDateTime(2017, 6, 6, 0, 0)
+   >>> d.end
+   FiscalDateTime(2017, 6, 6, 23, 59, 59)
+   >>> d in a
+   True
+   >>> d in b
+   True
+   >>> d in c
+   True
+
+You can also get the current ``FiscalDay`` with:
+
+.. code-block:: python
+
+   >>> FiscalDay.current()
+   FiscalDay(2018, 94)
+
+
 FiscalDateTime
 --------------
 
@@ -95,18 +143,18 @@ The start and end of each quarter are stored as instances of the ``FiscalDateTim
 
 .. code-block:: python
 
-   >>> c = FiscalDateTime.now()
-   >>> c
+   >>> e = FiscalDateTime.now()
+   >>> e
    FiscalDateTime(2017, 4, 8, 20, 30, 31, 105323)
-   >>> c.fiscal_year
+   >>> e.fiscal_year
    2017
-   >>> c.quarter
+   >>> e.quarter
    3
-   >>> c.next_quarter
+   >>> e.next_quarter
    FiscalQuarter(2017, 4)
-   >>> c.fiscal_month
+   >>> e.fiscal_month
    7
-   >>> c.fiscal_day
+   >>> e.fiscal_day
    190
 
 
@@ -117,12 +165,12 @@ If you don't care about the time component of the ``FiscalDateTime`` class, the 
 
 .. code-block:: python
 
-   >>> d = FiscalDate.today()
-   >>> d
+   >>> f = FiscalDate.today()
+   >>> f
    FiscalDate(2017, 4, 8)
-   >>> d.fiscal_year
+   >>> f.fiscal_year
    2017
-   >>> d.prev_fiscal_year
+   >>> f.prev_fiscal_year
    FiscalYear(2016)
 
 

--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,8 @@ You can also get the current ``FiscalQuarter`` with:
 FiscalMonth
 -----------
 
+The ``FiscalMonth`` class allows you to keep track of the fiscal month.
+
 .. code-block:: python
 
    >>> c = FiscalMonth(2017, 9)
@@ -117,6 +119,8 @@ You can also get the current ``FiscalMonth`` with:
 
 FiscalDay
 ----------
+
+To keep track of the fiscal day, use the ``FiscalDay`` class.
 
 .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ You can also get the current ``FiscalQuarter`` with:
 
 
 FiscalMonth
-----------
+-----------
 
 .. code-block:: python
 
@@ -131,7 +131,7 @@ FiscalDay
    True
    >>> d in c
    True
-   >>>d.next_fiscal_day
+   >>> d.next_fiscal_day
    FiscalDay(2017, 251)
 
 You can also get the current ``FiscalDay`` with:
@@ -145,7 +145,7 @@ You can also get the current ``FiscalDay`` with:
 FiscalDateTime
 --------------
 
-The start and end of each quarter are stored as instances of the ``FiscalDateTime`` class. This class provides all of the same features as the ``datetime`` class, with the addition of the ability to query the fiscal year, fiscal quarter, fiscal month, and fiscal day.
+The start and end of each of the above objects are stored as instances of the ``FiscalDateTime`` class. This class provides all of the same features as the ``datetime`` class, with the addition of the ability to query the fiscal year, fiscal quarter, fiscal month, and fiscal day.
 
 .. code-block:: python
 

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -64,6 +64,54 @@ You can also get the current ``FiscalQuarter`` with:
    FiscalQuarter(2018, 2)
 
 
+FiscalMonth
+----------
+
+.. code-block:: python
+
+   >>> c = FiscalMonth(2017, 9)
+   >>> c.start
+   FiscalDateTime(2017, 6, 1, 0, 0)
+   >>> c.end
+   FiscalDateTime(2017, 6, 30, 23, 59, 59)
+   >>> c in a
+   True
+   >>> c in b
+   True
+
+You can also get the current ``FiscalMonth`` with:
+
+.. code-block:: python
+
+   >>> FiscalMonth.current()
+   FiscalMonth(2018, 4)
+
+
+FiscalDay
+----------
+
+.. code-block:: python
+
+   >>> d = FiscalDay(2017, 250)
+   >>> d.start
+   FiscalDateTime(2017, 6, 6, 0, 0)
+   >>> d.end
+   FiscalDateTime(2017, 6, 6, 23, 59, 59)
+   >>> d in a
+   True
+   >>> d in b
+   True
+   >>> d in c
+   True
+
+You can also get the current ``FiscalDay`` with:
+
+.. code-block:: python
+
+   >>> FiscalDay.current()
+   FiscalDay(2018, 94)
+
+
 FiscalDateTime
 --------------
 
@@ -71,18 +119,18 @@ The start and end of each quarter are stored as instances of the ``FiscalDateTim
 
 .. code-block:: python
 
-   >>> c = FiscalDateTime.now()
-   >>> c
+   >>> e = FiscalDateTime.now()
+   >>> e
    FiscalDateTime(2017, 4, 8, 20, 30, 31, 105323)
-   >>> c.fiscal_year
+   >>> e.fiscal_year
    2017
-   >>> c.quarter
+   >>> e.quarter
    3
-   >>> c.next_quarter
+   >>> e.next_quarter
    FiscalQuarter(2017, 4)
-   >>> c.fiscal_month
+   >>> e.fiscal_month
    7
-   >>> c.fiscal_day
+   >>> e.fiscal_day
    190
 
 
@@ -93,10 +141,10 @@ If you don't care about the time component of the ``FiscalDateTime`` class, the 
 
 .. code-block:: python
 
-   >>> d = FiscalDate.today()
-   >>> d
+   >>> f = FiscalDate.today()
+   >>> f
    FiscalDate(2017, 4, 8)
-   >>> d.fiscal_year
+   >>> f.fiscal_year
    2017
-   >>> d.prev_fiscal_year
+   >>> f.prev_fiscal_year
    FiscalYear(2016)

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -67,7 +67,9 @@ You can also get the current ``FiscalQuarter`` with:
 
 
 FiscalMonth
-----------
+-----------
+
+The ``FiscalMonth`` class allows you to keep track of the fiscal month.
 
 .. code-block:: python
 
@@ -94,6 +96,8 @@ You can also get the current ``FiscalMonth`` with:
 FiscalDay
 ----------
 
+To keep track of the fiscal day, use the ``FiscalDay`` class.
+
 .. code-block:: python
 
    >>> d = FiscalDay(2017, 250)
@@ -107,7 +111,7 @@ FiscalDay
    True
    >>> d in c
    True
-   >>>d.next_fiscal_day
+   >>> d.next_fiscal_day
    FiscalDay(2017, 251)
 
 You can also get the current ``FiscalDay`` with:
@@ -121,7 +125,7 @@ You can also get the current ``FiscalDay`` with:
 FiscalDateTime
 --------------
 
-The start and end of each quarter are stored as instances of the ``FiscalDateTime`` class. This class provides all of the same features as the ``datetime`` class, with the addition of the ability to query the fiscal year, fiscal quarter, fiscal month, and fiscal day.
+The start and end of each of the above objects are stored as instances of the ``FiscalDateTime`` class. This class provides all of the same features as the ``datetime`` class, with the addition of the ability to query the fiscal year, fiscal quarter, fiscal month, and fiscal day.
 
 .. code-block:: python
 

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -54,6 +54,8 @@ These objects represent the standalone ``FiscalQuarter`` class.
    True
    >>> b in a
    True
+   >>> b.next_quarter
+   FiscalQuarter(2017, 4)
 
 You can also get the current ``FiscalQuarter`` with:
 
@@ -78,6 +80,8 @@ FiscalMonth
    True
    >>> c in b
    True
+   >>> c.next_fiscal_month
+   FiscalMonth(2017, 10)
 
 You can also get the current ``FiscalMonth`` with:
 
@@ -103,6 +107,8 @@ FiscalDay
    True
    >>> d in c
    True
+   >>>d.next_fiscal_day
+   FiscalDay(2017, 251)
 
 You can also get the current ``FiscalDay`` with:
 


### PR DESCRIPTION
Relatively simple expansion of documentation of FiscalMonth and FiscalDay. I added `next_quarter` into FiscalQuarter also.

This is basically a copy of the latter part of the FiscalQuarter section. Not sure if the sections each need an intro line of some sort.

I also have mixed feelings about the variables flowing through and essentially requiring you to read the whole document in order to get the context (e.g. the worst "offender" is `d in a` from basic_usage.rst:100).

Making these changes also makes me realize I created some asymmetry in the API by not adding next_fiscal_* attributes to FiscalBase...