### PR TITLE
Removing warnings filter changes from package

### DIFF
--- a/fiscalyear.py
+++ b/fiscalyear.py
@@ -8,12 +8,7 @@ __version__ = "0.3.2"
 import calendar
 import contextlib
 import datetime
-import sys
 import warnings
-
-
-if not sys.warnoptions:
-    warnings.simplefilter("default")
 
 # Number of months in each quarter
 MONTHS_PER_QUARTER = 12 // 4


### PR DESCRIPTION
The code `warnings.simplefilter("default")` expands what warnings are shown and can cause warnings and errors which are normally not expected in other packages to show. In addition, depending on the import order this can override changes to the warnings filter made by the user. I think it would be better to remove this from the package to prevent issues caused by users receiving unexpected warnings/errors.