### PR TITLE
Drop Python 2 support

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: '3.10'
     - name: Install Black
       run: pip3 install black
     - name: Run Black Checks

--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: '3.10'
     - name: Install dependencies
       run: pip install flake8
     - name: Run flake8 checks

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
     steps:
     - name: Clone repository
       uses: actions/checkout@v2

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,7 +49,7 @@ master_doc = "index"
 # General information about the project.
 project = fiscalyear.__name__
 author = fiscalyear.__author__
-copyright = u"2017, " + author
+copyright = "2017, " + author
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -128,7 +128,7 @@ latex_documents = [
     (
         master_doc,
         "fiscalyear.tex",
-        u"fiscalyear Documentation",
+        "fiscalyear Documentation",
         fiscalyear.__author__,
         "manual",
     )
@@ -139,7 +139,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "fiscalyear", u"fiscalyear Documentation", [author], 1)]
+man_pages = [(master_doc, "fiscalyear", "fiscalyear Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -151,7 +151,7 @@ texinfo_documents = [
     (
         master_doc,
         "fiscalyear",
-        u"fiscalyear Documentation",
+        "fiscalyear Documentation",
         author,
         "fiscalyear",
         "fiscalyear is a small, lightweight Python module providing helpful "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,5 +6,5 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-target-version = ['py27', 'py33', 'py34', 'py35', 'py36', 'py37', 'py38']
+target-version = ['py35', 'py36', 'py37', 'py38', 'py39']
 include = 'docs/conf\.py|fiscalyear\.py|setup\.py|test_fiscal_year\.py'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 codecov
-pytest~=4.6
+pytest
 pytest-cov
-pytest-mock~=2.0
+pytest-mock
 sphinx>=1.4
 sphinx_rtd_theme

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,16 +14,7 @@ classifiers =
     License :: OSI Approved :: MIT License
     # Supported Python versions
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.5
-    Programming Language :: Python :: 2.6
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.0
-    Programming Language :: Python :: 3.1
-    Programming Language :: Python :: 3.2
-    Programming Language :: Python :: 3.3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
@@ -40,5 +31,5 @@ long_description = file: README.rst
 keywords = fiscal year, fiscal quarter, calendar, datetime
 
 [options]
-python_requires = >=2.5
+python_requires = >=3.5
 py_modules = fiscalyear


### PR DESCRIPTION
I'm going to be adding type hints which requires Python 3.5+.